### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "prepare": "husky install",
+    "prepare": "husky",
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "infra:up": "docker-compose up -d",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)